### PR TITLE
jQA setup and initial reports

### DIFF
--- a/moduliths-sample/jqassistant/index.adoc
+++ b/moduliths-sample/jqassistant/index.adoc
@@ -1,0 +1,79 @@
+= Modulith
+
+== Overview
+
+include::jQA:Summary[]
+
+[[default]]
+[role=group,includesConcepts="modulith:ModuleDependencies,modulith:ModuleExposesType"]
+== Reports
+
+[[modulith:ModulithApplication]]
+[source,cypher,role=concept]
+.Classes annotated by `de.olivergierke.moduliths.Modulith` are labeled with `Modulith` and `Application`.
+----
+MATCH
+  (:Artifact)-[:CONTAINS]->(modulith:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(:Type{fqn:"de.olivergierke.moduliths.Modulith"})
+SET
+  modulith:Modulith:Application
+RETURN
+  modulith as Modulith
+----
+
+[[modulith:Module]]
+[source,cypher,role=concept,requiresConcepts="modulith:ModulithApplication"]
+.Each package that is located within the same package as the Modulith application class is labeled with `Module`.
+----
+MATCH
+  (root:Package)-[:CONTAINS]->(modulith:Modulith:Application),
+  (root)-[:CONTAINS]->(module:Package)
+OPTIONAL MATCH
+  (module)-[:CONTAINS]->(:Type{name:"package-info"})-[:ANNOTATED_BY]->(moduleInfo),
+  (moduleInfo)-[:OF_TYPE]->(:Type{fqn:"de.olivergierke.moduliths.Module"}),
+  (moduleInfo)-[:HAS]->(displayName:Value{name:"displayName"})
+SET
+  module:Module
+SET
+  module.displayName = coalesce(displayName.value, module.name)
+RETURN
+  module.displayName as Module
+ORDER BY
+  Module
+----
+
+[[modulith:ModuleDependencies]]
+[source,cypher,role=concept,requiresConcepts="modulith:Module",reportType="plantuml-component-diagram"]
+.A dependency between two modules exists if there's a type dependency between both. The module dependency is represented by `DEPENDS_ON_MODULE` relationships having a  `weight` property indicating the degree of coupling.
+----
+MATCH
+  (module1:Module)-[:CONTAINS*]->(type1:Type),
+  (module2:Module)-[:CONTAINS*]->(type2:Type),
+  (type1)-[dependsOn:DEPENDS_ON]->(type2)
+WHERE
+  module1 <> module2
+WITH
+  module1, module2, count(dependsOn) as weight
+MERGE
+  (module1)-[dependsOnModule:DEPENDS_ON_MODULE]->(module2)
+SET
+  dependsOnModule.weight = weight
+RETURN
+  module1, dependsOnModule, module2
+----
+
+[[modulith:ModuleExposesType]]
+[source,cypher,role=concept,requiresConcepts="modulith:ModuleDependencies"]
+.A type of a module is exposed if it is referenced at least once by a type in another module.
+----
+MATCH
+  (module:Module)
+OPTIONAL MATCH
+  (dependent:Module)-[:DEPENDS_ON_MODULE]->(module),
+  (dependent)-[:CONTAINS*]->(dependentType:Type),
+  (module)-[:CONTAINS*]->(type:Type),
+  (dependentType)-[:DEPENDS_ON]->(type)
+RETURN
+  module.displayName as Module, collect(type.fqn) as ExposedTypes
+ORDER BY
+  Module
+----

--- a/moduliths-sample/pom.xml
+++ b/moduliths-sample/pom.xml
@@ -13,6 +13,38 @@
 	<name>Moduliths - Sample</name>
 	<artifactId>moduliths-sample</artifactId>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.buschmais.jqassistant</groupId>
+				<artifactId>jqassistant-maven-plugin</artifactId>
+				<version>1.4.0</version>
+				<executions>
+					<execution>
+						<id>default-cli</id>
+						<goals>
+							<goal>scan</goal>
+							<goal>analyze</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<reportProperties>
+						<asciidoc.report.rule.directory>${project.basedir}/jqassistant</asciidoc.report.rule.directory>
+						<asciidoc.report.rule.include>index.adoc</asciidoc.report.rule.include>
+					</reportProperties>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.jqassistant.contrib.plugin</groupId>
+						<artifactId>jqassistant-asciidoc-report-plugin</artifactId>
+						<version>1.1.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
 	<dependencies>
 
 		<dependency>


### PR DESCRIPTION
- Integrated jQA into the moduliths-sample module
- Added rules based on the proposed module layout to create reports as component diagrams and tables: modules, module dependencies and types exposed by a module to other modules
- HTML report is available after mvn install in moduliths-sample/target/jqassistant/report/asciidoc
- In the future those rules may be delivered as a jQAssistant plugin
