### PR TITLE
Upgrade ArchUnit to 0.10.2

### DIFF
--- a/moduliths-test/pom.xml
+++ b/moduliths-test/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit</artifactId>
-			<version>0.10.1</version>
+			<version>0.10.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Fixes a bug where JavaPackage.dependenciesFromSelf sometimes contains the package itself.