### PR TITLE
Avoid StackOverflow in ModuleDetectionStrategy.explictlyAnnotated()

### DIFF
--- a/moduliths-core/src/main/java/org/moduliths/model/ModuleDetectionStrategy.java
+++ b/moduliths-core/src/main/java/org/moduliths/model/ModuleDetectionStrategy.java
@@ -52,6 +52,6 @@ public interface ModuleDetectionStrategy {
 	 * @return will never be {@literal null}.
 	 */
 	static ModuleDetectionStrategy explictlyAnnotated() {
-		return ModuleDetectionStrategy.EXPLICITLY_ANNOTATED;
+		return ModuleDetectionStrategies.EXPLICITLY_ANNOTATED;
 	}
 }

--- a/moduliths-core/src/main/java/org/moduliths/model/ModuleDetectionStrategy.java
+++ b/moduliths-core/src/main/java/org/moduliths/model/ModuleDetectionStrategy.java
@@ -52,6 +52,6 @@ public interface ModuleDetectionStrategy {
 	 * @return will never be {@literal null}.
 	 */
 	static ModuleDetectionStrategy explictlyAnnotated() {
-		return ModuleDetectionStrategy.explictlyAnnotated();
+		return ModuleDetectionStrategy.EXPLICITLY_ANNOTATED;
 	}
 }


### PR DESCRIPTION
The method calls itself recursively which leads to a StackOverflowError