### PR TITLE
no need this line, since mark event completed will be done in Complet…

### DIFF
--- a/moduliths-events/moduliths-events-core/src/main/java/org/moduliths/events/support/PersistentApplicationEventMulticaster.java
+++ b/moduliths-events/moduliths-events-core/src/main/java/org/moduliths/events/support/PersistentApplicationEventMulticaster.java
@@ -129,7 +129,6 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 		try {
 
 			listener.onApplicationEvent(publication.getApplicationEvent());
-			registry.get().markCompleted(publication);
 
 		} catch (Exception e) {
 


### PR DESCRIPTION
no need this line, since mark event completed will be done in CompletionRegisteringBeanPostProcessor, and if exception happened inside listener it will not be caught here and will be marked as completed